### PR TITLE
Go Scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+main
+debug
+bin
+vendor
+LICENSE
+Makefile
+trash.yml

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,0 +1,15 @@
+FROM golang:1.6
+RUN go get github.com/rancher/trash
+RUN go get github.com/golang/lint/golint
+RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker && \
+    chmod +x /usr/bin/docker
+ENV PATH /go/bin:$PATH
+ENV DAPPER_SOURCE /go/src/github.com/rancher/scheduler
+ENV DAPPER_OUTPUT bin
+ENV DAPPER_DOCKER_SOCKET true
+ENV DAPPER_ENV TAG REPO
+ENV GO15VENDOREXPERIMENT 1
+ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
+WORKDIR ${DAPPER_SOURCE}
+ENTRYPOINT ["./scripts/entry"]
+CMD ["ci"]

--- a/cache/host-info.go
+++ b/cache/host-info.go
@@ -21,12 +21,13 @@ type DiskInfo struct {
 }
 
 type HostInfo struct {
-	HostId        string
-	EnvId         string
-	CpuTotalCount float64
-	CpuUsed       float64
-	MemTotalInMB  float64
-	MemUsedInMB   float64
+	HostId            string
+	EnvId             string
+	CpuTotalCount     float64
+	CpuUsed           float64
+	MemTotalInMB      float64
+	MemUsedInMB       float64
+	NotCompleteLoaded bool
 
 	// key: device path (/dev/sda) without /dev prefix
 	Disks map[string]*DiskInfo

--- a/cache/host-info.go
+++ b/cache/host-info.go
@@ -1,0 +1,203 @@
+package cache
+
+import (
+	log "github.com/Sirupsen/logrus"
+	rancherClient "github.com/rancher/go-rancher/client"
+	schedulerClient "github.com/rancher/scheduler/client"
+	"strconv"
+	"strings"
+)
+
+type IopsInfo struct {
+	ReadTotal      uint64
+	ReadAllocated  uint64
+	WriteTotal     uint64
+	WriteAllocated uint64
+}
+
+type DiskInfo struct {
+	DevicePath string
+	Iops       IopsInfo
+}
+
+type HostInfo struct {
+	HostId        string
+	EnvId         string
+	CpuTotalCount float64
+	CpuUsed       float64
+	MemTotalInMB  float64
+	MemUsedInMB   float64
+
+	// key: device path (/dev/sda) without /dev prefix
+	Disks map[string]*DiskInfo
+
+	// key: instance id
+	Instances map[string]*InstanceInfo
+}
+
+const (
+	DefaultDiskPath = "default"
+	DivisionFactorOfVcpu = 2
+)
+
+// return true means allocated, otherwise not allocated anything
+func (host *HostInfo) AllocateIopsForInstance(labels map[string]interface{}, instanceId string) {
+	var readIopsReserved uint64
+	var writeIopsReserved uint64
+	hasLabels := false
+	for k, v := range labels {
+		if v == nil {
+			continue
+		}
+		labelValue := v.(string)
+		if strings.HasPrefix(k, ReadIopsLabel) {
+			readIopsReserved, _ = strconv.ParseUint(labelValue, 10, 64)
+			hasLabels = true
+		} else if strings.HasPrefix(k, WriteIopsLabel) {
+			writeIopsReserved, _ = strconv.ParseUint(labelValue, 10, 64)
+			hasLabels = true
+		}
+	}
+	// no iops labels, we are done
+	if hasLabels == false {
+		log.Info("no iops labels")
+		return
+	}
+
+	log.Infof("allocate iops for instance id: %s, on host id: %s, readIopsReserved: %d, writeIopsReserved: %d", instanceId, host.HostId, readIopsReserved, writeIopsReserved)
+
+	// account for resource used by this instance. disk has to exist during GetHostInfo() call
+	diskInfo, ok := host.Disks[DefaultDiskPath]
+	if !ok {
+		log.Info("no disk on host for disk path:", DefaultDiskPath)
+		return
+	}
+	diskInfo.Iops.ReadAllocated += readIopsReserved
+	diskInfo.Iops.WriteAllocated += writeIopsReserved
+	log.Infof("host id:%s, after allocation, ReadAllocated: %d, WriteAllocated: %d", host.HostId, diskInfo.Iops.ReadAllocated, diskInfo.Iops.WriteAllocated)
+
+	// now cache reserved info for deallocation
+	instanceInfo, ok := host.Instances[instanceId]
+	if !ok {
+		// create an InstanceInfo for deallocation when instance is removed
+		instanceInfo = &InstanceInfo{instanceId, 0, 0, make(map[string]*DiskReserved)}
+		host.Instances[instanceId] = instanceInfo
+	}
+
+	// create and add an entry (replace it if exists)
+	diskReserved := &DiskReserved{DefaultDiskPath, readIopsReserved, writeIopsReserved}
+	instanceInfo.DisksReservedMap[DefaultDiskPath] = diskReserved
+}
+
+// return true means allocated, otherwise not allocated anything
+func (host *HostInfo) DeallocateIopsForInstance(instanceId string) {
+	instanceInfo, ok := host.Instances[instanceId]
+	if !ok {
+		log.Info("never allocated for instance id: ", instanceId)
+		return
+	}
+	diskReserved, ok := instanceInfo.DisksReservedMap[DefaultDiskPath]
+	if !ok {
+		log.Info("no disk reserved for instance id: ", instanceId, " with disk path", DefaultDiskPath)
+		return
+	}
+	readIopsReserved := diskReserved.ReadIopsReserved
+	writeIopsReserved := diskReserved.WriteIopsReserved
+	log.Infof("deallocate iops for instance id: %s, on host id: %s, readIopsReserved: %d, writeIopsReserved: %d", instanceId, host.HostId, readIopsReserved, writeIopsReserved)
+
+	// account for resource used by this instance
+	diskInfo, ok := host.Disks[DefaultDiskPath]
+	if !ok {
+		return
+	}
+	diskInfo.Iops.ReadAllocated -= readIopsReserved
+	diskInfo.Iops.WriteAllocated -= writeIopsReserved
+	log.Infof("host id:%s, after deallocation, ReadAllocated: %d, WriteAllocated: %d", host.HostId, diskInfo.Iops.ReadAllocated, diskInfo.Iops.WriteAllocated)
+
+	// remove a disksReserved map entry for instance
+	delete(instanceInfo.DisksReservedMap, DefaultDiskPath)
+}
+
+// instance resources are iops
+func (host *HostInfo) loadAllocatedContainerResource() error {
+	containerList, err := schedulerClient.GetContainersOnHost(host.HostId, host.EnvId)
+	if err != nil || containerList == nil || len(containerList) == 0 {
+		return err
+	}
+	for _, container := range containerList {
+		log.Infof("container name: %s, container id: %s", container.Name, container.Id)
+
+		// allocate resource for this container. container now just uses iops, no cpu/mem
+		host.AllocateIopsForInstance(container.Labels, container.Id)
+	}
+
+	return nil
+}
+
+// VM resources are cpu/mem
+func (host *HostInfo) loadAllocatedVMResource() error {
+	// first time we need to get all the container instances from cattle
+	// scheduled on that host
+	vmList, err := schedulerClient.GetVMsOnHost(host.HostId, host.EnvId)
+	if err != nil || vmList == nil || len(vmList) == 0 {
+		return err
+	}
+	for _, vm := range vmList {
+		log.Infof("vm name: %s, vm id: %s", vm.Name, vm.Id)
+
+		// vm need cpu and memory
+		host.AllocateCPUMemoryForVM(&vm)
+
+		// vm could reserve iops
+		host.AllocateIopsForInstance(vm.Labels, vm.Id)
+	}
+
+	return nil
+}
+
+func (host *HostInfo) AllocateCPUMemoryForVM(vm *rancherClient.VirtualMachine) {
+	log.Infof("vm name: %s, vm id: %s", vm.Name, vm.Id)
+
+	// calculate back from vcpu to cpu
+	cpuReserved := float64(vm.Vcpu) / DivisionFactorOfVcpu
+	memReserved := float64(vm.MemoryMb)
+	log.Infof("cpuReserved: %f, memReserved: %f", cpuReserved, memReserved)
+	log.Infof("allocate cpu and memory for vm id: %s, on host id: %s, cpuReserved: %f, memReserved: %f", vm.Id, host.HostId, cpuReserved, memReserved)
+
+	// account for cpu/mem resource used by this instance
+	host.CpuUsed += cpuReserved
+	host.MemUsedInMB += memReserved
+	log.Infof("host id: %s, after allocation, CpuUsed: %f, memReserved: %f", host.HostId, host.CpuUsed, host.MemUsedInMB)
+
+	// update instanceInfo if exists or create a new one
+	instanceInfo, ok := host.Instances[vm.Id]
+	if !ok {
+		// create an InstanceInfo for deallocation when instance is removed
+		host.Instances[vm.Id] = &InstanceInfo{vm.Id, cpuReserved, memReserved, make(map[string]*DiskReserved)}
+	} else {
+		instanceInfo.CpuReserved = cpuReserved
+		instanceInfo.MemReservedInMB = memReserved
+	}
+}
+
+func (host *HostInfo) DeallocateCPUMemoryForVM(instanceId string) {
+	instanceInfo, ok := host.Instances[instanceId]
+	if !ok {
+		return
+	}
+	cpuReserved := instanceInfo.CpuReserved
+	memReserved := instanceInfo.MemReservedInMB
+	log.Infof("deallocate cpu and memory for instance id: %s, on host id: %s, cpuReserved: %f, memReserved: %f", instanceId, host.HostId, cpuReserved, memReserved)
+
+	host.CpuUsed -= cpuReserved
+	host.MemUsedInMB -= memReserved
+	log.Infof("host id:%s, after deallocation, CpuUsed: %f, MemUsedInMB: %f", host.HostId, host.CpuUsed, host.MemUsedInMB)
+}
+
+func (host *HostInfo) RemoveInstanceInfo(instanceId string) {
+	_, ok := host.Instances[instanceId]
+	if !ok {
+		return
+	}
+	delete(host.Instances, instanceId)
+}

--- a/cache/host-info.go
+++ b/cache/host-info.go
@@ -36,7 +36,7 @@ type HostInfo struct {
 }
 
 const (
-	DefaultDiskPath = "default"
+	DefaultDiskPath      = "default"
 	DivisionFactorOfVcpu = 2
 )
 
@@ -64,7 +64,8 @@ func (host *HostInfo) AllocateIopsForInstance(labels map[string]interface{}, ins
 		return
 	}
 
-	log.Infof("allocate iops for instance id: %s, on host id: %s, readIopsReserved: %d, writeIopsReserved: %d", instanceId, host.HostId, readIopsReserved, writeIopsReserved)
+	log.Infof("allocate iops for instance id: %s, on host id: %s, readIopsReserved: %d, writeIopsReserved: %d",
+		instanceId, host.HostId, readIopsReserved, writeIopsReserved)
 
 	// account for resource used by this instance. disk has to exist during GetHostInfo() call
 	diskInfo, ok := host.Disks[DefaultDiskPath]
@@ -74,7 +75,8 @@ func (host *HostInfo) AllocateIopsForInstance(labels map[string]interface{}, ins
 	}
 	diskInfo.Iops.ReadAllocated += readIopsReserved
 	diskInfo.Iops.WriteAllocated += writeIopsReserved
-	log.Infof("host id:%s, after allocation, ReadAllocated: %d, WriteAllocated: %d", host.HostId, diskInfo.Iops.ReadAllocated, diskInfo.Iops.WriteAllocated)
+	log.Infof("host id:%s, after allocation, ReadAllocated: %d, WriteAllocated: %d", host.HostId,
+		diskInfo.Iops.ReadAllocated, diskInfo.Iops.WriteAllocated)
 
 	// now cache reserved info for deallocation
 	instanceInfo, ok := host.Instances[instanceId]
@@ -103,7 +105,8 @@ func (host *HostInfo) DeallocateIopsForInstance(instanceId string) {
 	}
 	readIopsReserved := diskReserved.ReadIopsReserved
 	writeIopsReserved := diskReserved.WriteIopsReserved
-	log.Infof("deallocate iops for instance id: %s, on host id: %s, readIopsReserved: %d, writeIopsReserved: %d", instanceId, host.HostId, readIopsReserved, writeIopsReserved)
+	log.Infof("deallocate iops for instance id: %s, on host id: %s, readIopsReserved: %d, writeIopsReserved: %d",
+		instanceId, host.HostId, readIopsReserved, writeIopsReserved)
 
 	// account for resource used by this instance
 	diskInfo, ok := host.Disks[DefaultDiskPath]
@@ -112,7 +115,8 @@ func (host *HostInfo) DeallocateIopsForInstance(instanceId string) {
 	}
 	diskInfo.Iops.ReadAllocated -= readIopsReserved
 	diskInfo.Iops.WriteAllocated -= writeIopsReserved
-	log.Infof("host id:%s, after deallocation, ReadAllocated: %d, WriteAllocated: %d", host.HostId, diskInfo.Iops.ReadAllocated, diskInfo.Iops.WriteAllocated)
+	log.Infof("host id:%s, after deallocation, ReadAllocated: %d, WriteAllocated: %d", host.HostId,
+		diskInfo.Iops.ReadAllocated, diskInfo.Iops.WriteAllocated)
 
 	// remove a disksReserved map entry for instance
 	delete(instanceInfo.DisksReservedMap, DefaultDiskPath)
@@ -162,12 +166,14 @@ func (host *HostInfo) AllocateCPUMemoryForVM(vm *rancherClient.VirtualMachine) {
 	cpuReserved := float64(vm.Vcpu) / DivisionFactorOfVcpu
 	memReserved := float64(vm.MemoryMb)
 	log.Infof("cpuReserved: %f, memReserved: %f", cpuReserved, memReserved)
-	log.Infof("allocate cpu and memory for vm id: %s, on host id: %s, cpuReserved: %f, memReserved: %f", vm.Id, host.HostId, cpuReserved, memReserved)
+	log.Infof("allocate cpu and memory for vm id: %s, on host id: %s, cpuReserved: %f, memReserved: %f",
+		vm.Id, host.HostId, cpuReserved, memReserved)
 
 	// account for cpu/mem resource used by this instance
 	host.CpuUsed += cpuReserved
 	host.MemUsedInMB += memReserved
-	log.Infof("host id: %s, after allocation, CpuUsed: %f, memReserved: %f", host.HostId, host.CpuUsed, host.MemUsedInMB)
+	log.Infof("host id: %s, after allocation, CpuUsed: %f, memReserved: %f", host.HostId,
+		host.CpuUsed, host.MemUsedInMB)
 
 	// update instanceInfo if exists or create a new one
 	instanceInfo, ok := host.Instances[vm.Id]
@@ -187,11 +193,13 @@ func (host *HostInfo) DeallocateCPUMemoryForVM(instanceId string) {
 	}
 	cpuReserved := instanceInfo.CpuReserved
 	memReserved := instanceInfo.MemReservedInMB
-	log.Infof("deallocate cpu and memory for instance id: %s, on host id: %s, cpuReserved: %f, memReserved: %f", instanceId, host.HostId, cpuReserved, memReserved)
+	log.Infof("deallocate cpu and memory for instance id: %s, on host id: %s, cpuReserved: %f, memReserved: %f",
+		instanceId, host.HostId, cpuReserved, memReserved)
 
 	host.CpuUsed -= cpuReserved
 	host.MemUsedInMB -= memReserved
-	log.Infof("host id:%s, after deallocation, CpuUsed: %f, MemUsedInMB: %f", host.HostId, host.CpuUsed, host.MemUsedInMB)
+	log.Infof("host id:%s, after deallocation, CpuUsed: %f, MemUsedInMB: %f", host.HostId,
+		host.CpuUsed, host.MemUsedInMB)
 }
 
 func (host *HostInfo) RemoveInstanceInfo(instanceId string) {

--- a/cache/instance-info.go
+++ b/cache/instance-info.go
@@ -1,0 +1,22 @@
+package cache
+
+type DiskReserved struct {
+	DevicePath        string
+	ReadIopsReserved  uint64
+	WriteIopsReserved uint64
+}
+
+type InstanceInfo struct {
+	InstanceId      string
+	CpuReserved     float64
+	MemReservedInMB float64
+
+	// key: device name (/dev/sda) without /dev, so just sda
+	// value: reserved iops for read
+	DisksReservedMap map[string]*DiskReserved
+}
+
+const (
+	ReadIopsLabel  = "io.rancher.resource.read_iops"
+	WriteIopsLabel = "io.rancher.resource.write_iops"
+)

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -35,7 +35,9 @@ func (mgr *cacheManager) GetHostInfo(hostId string, envId string) *HostInfo {
 		env.HostInfos = make(map[string]*HostInfo)
 	}
 	hostInfo, ok := env.HostInfos[hostId]
-	if !ok {
+
+	// either host cache does not exist or not complete last time loaded
+	if !ok || hostInfo.NotCompleteLoaded {
 		// get the host from cattle and cache it if it is a valid id
 		host, err := schedulerClient.GetHost(hostId)
 		if err != nil || host == nil {
@@ -100,6 +102,10 @@ func loadHostInfoToCache(host *rancherClient.Host) *HostInfo {
 
 	hostInfo.CpuTotalCount = cpuCount
 	hostInfo.MemTotalInMB = memTotal
+	if cpuCount == 0 || memTotal == 0 {
+		hostInfo.NotCompleteLoaded = true
+		log.Info("either cpu count or memory total is not loaded completely")
+	}
 
 	// get iops, we just use the first device
 	iopsInfo, ok := info["iopsInfo"].(map[string]interface{})
@@ -122,6 +128,10 @@ func loadHostInfoToCache(host *rancherClient.Host) *HostInfo {
 		k = DefaultDiskPath // just set it to default for now
 		hostInfo.Disks[k] = &DiskInfo{k, IopsInfo{ReadTotal: uint64(readIops), WriteTotal: uint64(writeIops)}}
 		log.Infof("ReadTotal IOPS: %d, WriteTotal IOPS: %d, Disk Path: %s", uint64(readIops), uint64(writeIops), k)
+	}
+	if len(iopsInfo) == 0 {
+		hostInfo.NotCompleteLoaded = true
+		log.Info("iopsInfo is not loaded completely")
 	}
 
 	return hostInfo

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -1,0 +1,120 @@
+package cache
+
+import (
+	log "github.com/Sirupsen/logrus"
+	rancherClient "github.com/rancher/go-rancher/client"
+	schedulerClient "github.com/rancher/scheduler/client"
+)
+
+type environment struct {
+	// key: host id
+	HostInfos map[string]*HostInfo
+}
+
+type cacheManager struct {
+	// key: environment id (account id)
+	Envs map[string]*environment
+}
+
+var (
+	// the only instance of cache manager
+	Manager = &cacheManager{}
+)
+
+func (mgr *cacheManager) GetHostInfo(hostId string, envId string) *HostInfo {
+	if mgr.Envs == nil {
+		mgr.Envs = make(map[string]*environment)
+	}
+	env, ok := mgr.Envs[envId]
+	if !ok {
+		// create an environment
+		env = &environment{}
+		mgr.Envs[envId] = env
+	}
+	if env.HostInfos == nil {
+		env.HostInfos = make(map[string]*HostInfo)
+	}
+	hostInfo, ok := env.HostInfos[hostId]
+	if !ok {
+		// get the host from cattle and cache it if it is a valid id
+		host, err := schedulerClient.GetHost(hostId)
+		if err != nil || host == nil {
+			log.Errorf("can't get host from cattle using host id: %s", hostId)
+			return nil
+		}
+
+		// load host info to cache
+		hostInfo = loadHostInfoToCache(host)
+		env.HostInfos[hostId] = hostInfo
+
+		// load alloated resources from instances exist on this host
+		err = hostInfo.loadAllocatedContainerResource()
+		if err != nil {
+			log.Errorf("can't loadAllocatedContainerResource for host id: %s", hostId)
+			return nil
+		}
+		err = hostInfo.loadAllocatedVMResource()
+		if err != nil {
+			log.Errorf("can't loadAllocatedVMResource for host id: %s", hostId)
+			return nil
+		}
+	}
+	return hostInfo
+}
+
+// used to remove host in case it doesnt exist anymore
+func RemoveHostInfoFromCache() {
+	return
+}
+
+func loadHostInfoToCache(host *rancherClient.Host) *HostInfo {
+	// there are several types of resources we need to load into cache
+	// cpu, memory, iops
+	hostInfo := &HostInfo{HostId: host.Id, EnvId: host.AccountId}
+	hostInfo.Disks = make(map[string]*DiskInfo)
+	hostInfo.Instances = make(map[string]*InstanceInfo)
+
+	// get cpu count
+	info, _ := host.Info.(map[string]interface{})
+	cpuInfo := info["cpuInfo"].(map[string]interface{})
+	cpuCount := cpuInfo["count"].(float64)
+	log.Info("cpu count: ", cpuCount)
+
+	// get memory total in MB
+	memInfo := info["memoryInfo"].(map[string]interface{})
+	memTotal := memInfo["memTotal"].(float64)
+	log.Info("memTotal: ", memTotal)
+
+	// get iops, we just use the first device
+	iopsInfo := info["iopsInfo"].(map[string]interface{})
+	for k, v := range iopsInfo {
+		iops := v.(map[string]interface{})
+		readIops := iops["read"].(float64)
+		writeIops := iops["write"].(float64)
+		k = DefaultDiskPath // just set it to default for now
+		hostInfo.Disks[k] = &DiskInfo{k, IopsInfo{ReadTotal: uint64(readIops), WriteTotal: uint64(writeIops)}}
+	}
+
+	hostInfo.CpuTotalCount = cpuCount
+	hostInfo.MemTotalInMB = memTotal
+
+	return hostInfo
+}
+
+func (mgr *cacheManager) RemoveHostInfo(hostId string, envId string) {
+	if mgr.Envs == nil {
+		return
+	}
+	env, ok := mgr.Envs[envId]
+	if !ok {
+		return
+	}
+	if env.HostInfos == nil {
+		return
+	}
+	_, ok = env.HostInfos[hostId]
+	if !ok {
+		return
+	}
+	delete(env.HostInfos, hostId)
+}

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -121,6 +121,7 @@ func loadHostInfoToCache(host *rancherClient.Host) *HostInfo {
 		}
 		k = DefaultDiskPath // just set it to default for now
 		hostInfo.Disks[k] = &DiskInfo{k, IopsInfo{ReadTotal: uint64(readIops), WriteTotal: uint64(writeIops)}}
+		log.Infof("ReadTotal IOPS: %d, WriteTotal IOPS: %d, Disk Path: %s", uint64(readIops), uint64(writeIops), k)
 	}
 
 	return hostInfo

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,165 @@
+package client
+
+import (
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/rancher/go-rancher/client"
+	"os"
+)
+
+var (
+	rancherClient *client.RancherClient
+)
+
+// GetHosts: get hosts from cattle
+func getRancherClient() (*client.RancherClient, error) {
+	if rancherClient != nil {
+		return rancherClient, nil
+	}
+	cattleURL := os.Getenv("CATTLE_URL")
+	if len(cattleURL) == 0 {
+		log.Info("getRancherClient: CATTLE_URL is not set")
+		return nil, nil
+	}
+
+	cattleAccessKey := os.Getenv("CATTLE_ACCESS_KEY")
+	if len(cattleAccessKey) == 0 {
+		log.Info("getRancherClient: CATTLE_ACCESS_KEY is not set")
+		return nil, nil
+	}
+
+	cattleSecretKey := os.Getenv("CATTLE_SECRET_KEY")
+	if len(cattleSecretKey) == 0 {
+		log.Info("getRancherClient: CATTLE_SECRET_KEY is not set")
+		return nil, nil
+	}
+
+	opts := &client.ClientOpts{
+		Url:       cattleURL,
+		AccessKey: cattleAccessKey,
+		SecretKey: cattleSecretKey,
+	}
+
+	var err error = nil
+	rancherClient, err = client.NewRancherClient(opts)
+
+	if err != nil {
+		log.Fatalf("Failed to create Rancher client %v", err)
+		rancherClient = nil
+	}
+	return rancherClient, err
+}
+
+// GetHost: get host data from cattle
+func GetHost(hostId string) (*client.Host, error) {
+	clientPtr, err := getRancherClient()
+	if err != nil {
+		log.Fatalf("Failed to get Rancher client %v", err)
+		return nil, err
+	}
+	host, err := clientPtr.Host.ById(hostId)
+	if err != nil {
+		return nil, fmt.Errorf("Coudln't get host with id:%s. Error: %#v", hostId, err)
+	}
+
+	return host, nil
+}
+
+// GetInstance: get instance data from cattle
+func GetInstance(instanceId string) (*client.Instance, error) {
+	clientPtr, err := getRancherClient()
+	if err != nil {
+		log.Fatalf("Failed to get Rancher client %v", err)
+		return nil, err
+	}
+	instance, err := clientPtr.Instance.ById(instanceId)
+	if err != nil {
+		return nil, fmt.Errorf("Coudln't get instance with id:%s. Error: %#v", instanceId, err)
+	}
+
+	return instance, nil
+}
+
+// GetInstance: get instance data from cattle
+func GetContainer(containerId string) (*client.Container, error) {
+	clientPtr, err := getRancherClient()
+	if err != nil {
+		log.Fatalf("Failed to get Rancher client %v", err)
+		return nil, err
+	}
+	container, err := clientPtr.Container.ById(containerId)
+	if err != nil {
+		return nil, fmt.Errorf("Coudln't get container with id:%s. Error: %#v", containerId, err)
+	}
+
+	return container, nil
+}
+
+// GetContainersOnHost: get all containers for a host from cattle
+func GetContainersOnHost(hostId string, envId string) ([]client.Container, error) {
+	clientPtr, err := getRancherClient()
+	if err != nil {
+		log.Fatalf("Failed to get Rancher client %v", err)
+		return nil, err
+	}
+	opts := client.NewListOpts()
+	opts.Filters["accountId"] = envId
+	opts.Filters["allocationState"] = "active"
+
+	containerCollection, err := clientPtr.Container.List(opts)
+	if err != nil {
+		return nil, fmt.Errorf("Coudln't get container list on host by id [%s]. Error: %#v", hostId, err)
+	}
+
+	// filters by hostId, which opts does not support
+	containerList := make([]client.Container, 0)
+	for _, container := range containerCollection.Data {
+		if container.HostId == hostId {
+			containerList = append(containerList, container)
+		}
+	}
+	log.Infof("got all the containers with hostId %s", hostId)
+	return containerList, nil
+}
+
+// GetInstance: get instance data from cattle
+func GetVM(instanceId string) (*client.VirtualMachine, error) {
+	clientPtr, err := getRancherClient()
+	if err != nil {
+		log.Fatalf("Failed to get Rancher client %v", err)
+		return nil, err
+	}
+	vm, err := clientPtr.VirtualMachine.ById(instanceId)
+	if err != nil {
+		return nil, fmt.Errorf("Coudln't get vm instance with id:%s. Error: %#v", instanceId, err)
+	}
+
+	return vm, nil
+}
+
+// GetInstancesOnHost: get all instances for a host from cattle
+func GetVMsOnHost(hostId string, envId string) ([]client.VirtualMachine, error) {
+	clientPtr, err := getRancherClient()
+	if err != nil {
+		log.Fatalf("Failed to get Rancher client %v", err)
+		return nil, err
+	}
+	opts := client.NewListOpts()
+	opts.Filters["accountId"] = envId
+	opts.Filters["allocationState"] = "active"
+
+	vmCollection, err := clientPtr.VirtualMachine.List(opts)
+	if err != nil {
+		return nil, fmt.Errorf("Coudln't get vm instance list on host by id [%s]. Error: %#v", hostId, err)
+	}
+
+	// filters by hostId, which opts does not support
+	vmList := make([]client.VirtualMachine, 0)
+	for _, vm := range vmCollection.Data {
+		if vm.HostId == hostId {
+			vmList = append(vmList, vm)
+		}
+	}
+	log.Infof("got all the vm instances with hostId %s", hostId)
+	return vmList, nil
+}

--- a/client/client.go
+++ b/client/client.go
@@ -108,7 +108,8 @@ func GetContainersOnHost(hostId string, envId string) ([]client.Container, error
 
 	containerCollection, err := clientPtr.Container.List(opts)
 	if err != nil {
-		return nil, fmt.Errorf("Coudln't get container list on host by id [%s]. Error: %#v", hostId, err)
+		return nil, fmt.Errorf("Coudln't get container list on host by id [%s]. Error: %#v",
+			hostId, err)
 	}
 
 	// filters by hostId, which opts does not support
@@ -150,7 +151,8 @@ func GetVMsOnHost(hostId string, envId string) ([]client.VirtualMachine, error) 
 
 	vmCollection, err := clientPtr.VirtualMachine.List(opts)
 	if err != nil {
-		return nil, fmt.Errorf("Coudln't get vm instance list on host by id [%s]. Error: %#v", hostId, err)
+		return nil, fmt.Errorf("Coudln't get vm instance list on host by id [%s]. Error: %#v",
+			hostId, err)
 	}
 
 	// filters by hostId, which opts does not support

--- a/main.go
+++ b/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	log "github.com/Sirupsen/logrus"
+	"github.com/rancher/scheduler/service"
+)
+
+func main() {
+	log.Infof("Starting Rancher Scheduler service")
+	router := service.NewRouter()
+	handler := service.MuxWrapper{true, router}
+
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", 8090), &handler))
+}

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:15.10
+COPY scheduler /usr/bin/
+CMD ["scheduler"]

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/version
+
+cd $(dirname $0)/..
+
+mkdir -p bin
+go build -ldflags "-X main.VERSION=$VERSION -linkmode external -extldflags -static" -o bin/scheduler

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)
+
+./build
+./test
+./validate
+./package

--- a/scripts/entry
+++ b/scripts/entry
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+trap "chown -R $DAPPER_UID:$DAPPER_GID ." exit
+
+mkdir -p bin
+if [ -e ./scripts/$1 ]; then
+    ./scripts/"$@"
+else
+    "$@"
+fi

--- a/scripts/package
+++ b/scripts/package
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/version
+
+cd $(dirname $0)/../package
+
+TAG=${TAG:-${VERSION}}
+REPO=${REPO:-rancher}
+
+cp ../bin/scheduler .
+docker build -t ${REPO}/scheduler:${TAG} .
+
+echo Built ${REPO}/scheduler:${TAG}

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec $(dirname $0)/ci

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/..
+
+echo Running tests
+
+PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
+
+go test -race -cover -tags=test ${PACKAGES}

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/..
+
+echo Running validation
+
+PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
+
+echo Running: go vet
+go vet ${PACKAGES}
+echo Running: golint
+for i in ${PACKAGES}; do
+    if [ -n "$(golint $i | grep -v 'should have comment.*or be unexported' | tee /dev/stderr)" ]; then
+        failed=true
+    fi
+done
+test -z "$failed"
+echo Running: go fmt
+test -z "$(go fmt ${PACKAGES} | tee /dev/stderr)"

--- a/scripts/version
+++ b/scripts/version
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    DIRTY="-dirty"
+fi
+
+COMMIT=$(git rev-parse --short HEAD)
+GIT_TAG=$(git tag -l --contains HEAD | head -n 1)
+
+if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
+    VERSION=$GIT_TAG
+else
+    VERSION="${COMMIT}${DIRTY}"
+fi

--- a/service/error.go
+++ b/service/error.go
@@ -1,0 +1,10 @@
+package service
+
+import "github.com/rancher/go-rancher/client"
+
+//SchedulerError structure contains the error resource definition
+type SchedulerError struct {
+	client.Resource
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -205,7 +205,7 @@ func ScheduleIops(w http.ResponseWriter, r *http.Request) {
 		diskInfo, ok := hostInfo.Disks[cache.DefaultDiskPath]
 		if !ok {
 			log.Info("no disk on host for disk path:", cache.DefaultDiskPath)
-			api.GetApiContext(r).Write(&resp)
+			api.GetApiContext(r).Write(&respNo)
 			return
 		}
 		freeReadIops := diskInfo.Iops.ReadTotal - diskInfo.Iops.ReadAllocated
@@ -220,7 +220,7 @@ func ScheduleIops(w http.ResponseWriter, r *http.Request) {
 		diskInfo, ok := hostInfo.Disks[cache.DefaultDiskPath]
 		if !ok {
 			log.Info("no disk on host for disk path:", cache.DefaultDiskPath)
-			api.GetApiContext(r).Write(&resp)
+			api.GetApiContext(r).Write(&respNo)
 			return
 		}
 		freeWriteIops := diskInfo.Iops.WriteTotal - diskInfo.Iops.WriteAllocated

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -1,0 +1,324 @@
+package service
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/rancher/go-rancher/api"
+	rancherClient "github.com/rancher/go-rancher/client"
+	"github.com/rancher/scheduler/cache"
+	"github.com/rancher/scheduler/client"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type Response struct {
+	rancherClient.Resource
+	Schedule string `json:"schedule"`
+}
+
+//ScheduleCPU is a handler for route /cpu and returns a collection of host ids that can be scheduled on
+func ScheduleCPUMemory(w http.ResponseWriter, r *http.Request) {
+	log.Info("ScheduleCPUMemory called")
+
+	hostId := r.FormValue("hostId")
+	vmId := r.FormValue("vmId")
+	envId := r.FormValue("envId")
+	log.Infof("received hostid: %s, vmId:%s, envId: %s", hostId, vmId, envId)
+
+	// response no means can't accomodate scheduling resource, all other cases,
+	// we just say yes due to all conditions
+	respNo := Response{rancherClient.Resource{Type: "schedule"}, "no"}
+	resp := Response{rancherClient.Resource{Type: "schedule"}, "yes"}
+
+	// get the hostInfo obj from cache, if not exists, it will reload
+	hostInfo := cache.Manager.GetHostInfo(hostId, envId)
+	if hostInfo == nil {
+		log.Info("can't get host id:", hostId)
+		api.GetApiContext(r).Write(&resp)
+		return
+	}
+
+	// get the VM by id
+	vm, err := client.GetVM(vmId)
+	if err != nil || vm == nil {
+		api.GetApiContext(r).Write(&resp)
+		return
+	}
+	log.Infof("vm name: %s, vm instance id: %s", vm.Name, vm.Id)
+
+	// calculate back from vcpu to cpu
+	cpuRequired := float64(vm.Vcpu) / cache.DivisionFactorOfVcpu
+	log.Infof("cpuRequired: %f", cpuRequired)
+
+	// calculate the free resource
+	freeCpu := hostInfo.CpuTotalCount - hostInfo.CpuUsed
+	if freeCpu < cpuRequired {
+		log.Infof("not enough cpu. require: %f, available: %f", cpuRequired, freeCpu)
+		api.GetApiContext(r).Write(&respNo)
+		return
+	}
+	log.Infof("Enough cpu. require: %f, available: %f", cpuRequired, freeCpu)
+	log.Infof("scheduler could accomodate cpu for vm")
+
+	memRequiredMB := float64(vm.MemoryMb)
+	log.Infof("required memRequiredMB: %f", memRequiredMB)
+
+	// calculate the free resource
+	freeMem := hostInfo.MemTotalInMB - hostInfo.MemUsedInMB
+	if freeMem < memRequiredMB {
+		log.Infof("not enough memory. require: %f, available: %f", memRequiredMB, freeMem)
+		api.GetApiContext(r).Write(&respNo)
+		return
+	}
+	log.Infof("Enough memory. require: %f, available: %f", memRequiredMB, freeMem)
+	log.Infof("scheduler could accomodate memory for vm")
+
+	api.GetApiContext(r).Write(&resp)
+}
+
+//ScheduleCPU is a handler for route /cpu and returns a collection of host ids that can be scheduled on
+func AllocateCPUMemory(w http.ResponseWriter, r *http.Request) {
+	log.Info("AllocateCPUMemory called")
+
+	hostId := r.FormValue("hostId")
+	vmId := r.FormValue("vmId")
+	envId := r.FormValue("envId")
+	log.Infof("received hostid: %s, vmId:%s, envId: %s", hostId, vmId, envId)
+
+	// get the hostInfo obj from cache, if not exists, it will reload
+	hostInfo := cache.Manager.GetHostInfo(hostId, envId)
+	if hostInfo == nil {
+		return
+	}
+
+	// get the VM by id
+	vm, err := client.GetVM(vmId)
+	if err != nil || vm == nil {
+		return
+	}
+	log.Infof("vm name: %s, vm instance id: %s", vm.Name, vm.Id)
+	hostInfo.AllocateCPUMemoryForVM(vm)
+
+	return
+}
+
+//ScheduleCPU is a handler for route /cpu and returns a collection of host ids that can be scheduled on
+func DeallocateCPUMemory(w http.ResponseWriter, r *http.Request) {
+	log.Info("DeallocateCPUMemory called")
+
+	hostId := r.FormValue("hostId")
+	vmId := r.FormValue("vmId")
+	envId := r.FormValue("envId")
+	log.Infof("received hostid: %s, vmId:%s, envId: %s", hostId, vmId, envId)
+
+	// get the hostInfo obj from cache, if not exists, it will reload
+	hostInfo := cache.Manager.GetHostInfo(hostId, envId)
+	if hostInfo == nil {
+		return
+	}
+
+	// get the VM by id
+	vm, err := client.GetVM(vmId)
+	if err != nil || vm == nil {
+		return
+	}
+	log.Infof("vm name: %s, vm instance id: %s", vm.Name, vm.Id)
+	hostInfo.DeallocateCPUMemoryForVM(vm.Id)
+
+	return
+}
+
+//ScheduleCPU is a handler for route /cpu and returns a collection of host ids that can be scheduled on
+func ScheduleIops(w http.ResponseWriter, r *http.Request) {
+	log.Info("ScheduleIops called")
+
+	hostId := r.FormValue("hostId")
+	instanceId := r.FormValue("instanceId")
+	envId := r.FormValue("envId")
+	log.Infof("received hostid: %s, instanceId:%s, envId: %s", hostId, instanceId, envId)
+
+	// response no means can't accomodate scheduling resource, all other cases,
+	// we just say yes due to all conditions
+	respNo := Response{rancherClient.Resource{Type: "schedule"}, "no"}
+	resp := Response{rancherClient.Resource{Type: "schedule"}, "yes"}
+
+	// get the hostInfo obj from cache, if not exists, it will reload
+	hostInfo := cache.Manager.GetHostInfo(hostId, envId)
+	if hostInfo == nil {
+		api.GetApiContext(r).Write(&resp)
+		return
+	}
+
+	var labels map[string]interface{}
+
+	// schedule iops for both container and vm
+	container, err := client.GetContainer(instanceId)
+	if err != nil {
+		api.GetApiContext(r).Write(&resp)
+		return
+	}
+	if container != nil {
+		labels = container.Labels
+		log.Info("schedule container for iops")
+	} else {
+		vm, err := client.GetVM(instanceId)
+		if err != nil {
+			api.GetApiContext(r).Write(&resp)
+			return
+		}
+		if vm != nil {
+			labels = vm.Labels
+			log.Info("schedule VM for iops")
+		}
+	}
+
+	// get resource requirements
+	var readIopsRequired uint64
+	var writeIopsRequired uint64
+	hasReadIopsLabel := false
+	hasWriteIopsLabel := false
+	for k, v := range labels {
+		if v == nil {
+			continue
+		}
+		labelValue := v.(string)
+		if strings.HasPrefix(k, cache.ReadIopsLabel) {
+			readIopsRequired, _ = strconv.ParseUint(labelValue, 10, 64)
+			hasReadIopsLabel = true
+		} else if strings.HasPrefix(k, cache.WriteIopsLabel) {
+			writeIopsRequired, _ = strconv.ParseUint(labelValue, 10, 64)
+			hasWriteIopsLabel = true
+		}
+	}
+	if !hasReadIopsLabel && !hasWriteIopsLabel {
+		log.Info("no iops labels")
+		api.GetApiContext(r).Write(&resp)
+		return
+	}
+	log.Infof("readIopsRequired: %d, writeIopsRequired: %d", readIopsRequired, writeIopsRequired)
+
+	// calculate the free resource
+	if hasReadIopsLabel {
+		diskInfo, ok := hostInfo.Disks[cache.DefaultDiskPath]
+		if !ok {
+			log.Info("no disk on host for disk path:", cache.DefaultDiskPath)
+			api.GetApiContext(r).Write(&resp)
+			return
+		}
+		freeReadIops := diskInfo.Iops.ReadTotal - diskInfo.Iops.ReadAllocated
+		if freeReadIops < readIopsRequired {
+			log.Infof("not enough read iops. require: %d, available: %d", readIopsRequired, freeReadIops)
+			api.GetApiContext(r).Write(&respNo)
+			return
+		}
+		log.Infof("Enough read iops. require: %d, available: %d", readIopsRequired, freeReadIops)
+	}
+	if hasWriteIopsLabel {
+		diskInfo, ok := hostInfo.Disks[cache.DefaultDiskPath]
+		if !ok {
+			log.Info("no disk on host for disk path:", cache.DefaultDiskPath)
+			api.GetApiContext(r).Write(&resp)
+			return
+		}
+		freeWriteIops := diskInfo.Iops.WriteTotal - diskInfo.Iops.WriteAllocated
+		if freeWriteIops < writeIopsRequired {
+			log.Infof("not enough write iops. require: %d, available: %d", writeIopsRequired, freeWriteIops)
+			api.GetApiContext(r).Write(&respNo)
+			return
+		}
+		log.Infof("Enough write iops. require: %d, available: %d", writeIopsRequired, freeWriteIops)
+	}
+
+	log.Infof("scheduler could accomodate iops for instance")
+
+	api.GetApiContext(r).Write(&resp)
+}
+
+//ScheduleCPU is a handler for route /cpu and returns a collection of host ids that can be scheduled on
+func AllocateIops(w http.ResponseWriter, r *http.Request) {
+	log.Info("AllocateIops called")
+
+	hostId := r.FormValue("hostId")
+	instanceId := r.FormValue("instanceId")
+	envId := r.FormValue("envId")
+	log.Infof("received hostid: %s, instanceId:%s, envId: %s", hostId, instanceId, envId)
+
+	// get the hostInfo obj from cache, if not exists, it will reload
+	hostInfo := cache.Manager.GetHostInfo(hostId, envId)
+	if hostInfo == nil {
+		return
+	}
+
+	// allocate iops for both container and vm
+	container, err := client.GetContainer(instanceId)
+	if err != nil {
+		return
+	}
+	if container != nil {
+		log.Info("allocate container for iops")
+		hostInfo.AllocateIopsForInstance(container.Labels, instanceId)
+		return
+	}
+	vm, err := client.GetVM(instanceId)
+	if err != nil {
+		return
+	}
+	if vm != nil {
+		log.Info("allocate VM for iops")
+		hostInfo.AllocateIopsForInstance(vm.Labels, instanceId)
+		return
+	}
+}
+
+//ScheduleCPU is a handler for route /cpu and returns a collection of host ids that can be scheduled on
+func DeallocateIops(w http.ResponseWriter, r *http.Request) {
+	log.Info("DeallocateIops called")
+
+	hostId := r.FormValue("hostId")
+	instanceId := r.FormValue("instanceId")
+	envId := r.FormValue("envId")
+	log.Infof("received hostid: %s, instanceId:%s, envId: %s", hostId, instanceId, envId)
+
+	// get the hostInfo obj from cache, if not exists, it will reload
+	hostInfo := cache.Manager.GetHostInfo(hostId, envId)
+	if hostInfo == nil {
+		return
+	}
+
+	log.Infof("instance id: %s", instanceId)
+	hostInfo.DeallocateIopsForInstance(instanceId)
+
+	return
+}
+
+//ScheduleCPU is a handler for route /cpu and returns a collection of host ids that can be scheduled on
+func RemoveInstance(w http.ResponseWriter, r *http.Request) {
+	log.Info("RemoveInstance called")
+
+	hostId := r.FormValue("hostId")
+	instanceId := r.FormValue("instanceId")
+	envId := r.FormValue("envId")
+	log.Infof("received hostid: %s, instanceId:%s, envId: %s", hostId, instanceId, envId)
+
+	// get the hostInfo obj from cache, if not exists, it will reload
+	hostInfo := cache.Manager.GetHostInfo(hostId, envId)
+	if hostInfo == nil {
+		return
+	}
+	hostInfo.RemoveInstanceInfo(instanceId)
+	log.Infof("removed instanceId:%s, from hostid: %s, envId: %s", instanceId, hostId, envId)
+	return
+}
+
+func RemoveHost(w http.ResponseWriter, r *http.Request) {
+	log.Info("RemoveHost called")
+
+	hostId := r.FormValue("hostId")
+	envId := r.FormValue("envId")
+	log.Infof("received hostid: %s, envId: %s", hostId, envId)
+
+	// get the hostInfo obj from cache, if not exists, it will reload
+	cache.Manager.RemoveHostInfo(hostId, envId)
+	log.Infof("removed hostid: %s, envId: %s", hostId, envId)
+	return
+}

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -16,7 +16,8 @@ type Response struct {
 	Schedule string `json:"schedule"`
 }
 
-//ScheduleCPU is a handler for route /cpu and returns a collection of host ids that can be scheduled on
+// ScheduleCPUMemory is a handler for route /cpu and returns a collection of host
+// ids that can be scheduled on
 func ScheduleCPUMemory(w http.ResponseWriter, r *http.Request) {
 	log.Info("ScheduleCPUMemory called")
 
@@ -76,7 +77,8 @@ func ScheduleCPUMemory(w http.ResponseWriter, r *http.Request) {
 	api.GetApiContext(r).Write(&resp)
 }
 
-//ScheduleCPU is a handler for route /cpu and returns a collection of host ids that can be scheduled on
+// AllocateCPUMemory is a handler for route /cpu and returns a collection of host ids that
+// can be scheduled on
 func AllocateCPUMemory(w http.ResponseWriter, r *http.Request) {
 	log.Info("AllocateCPUMemory called")
 
@@ -102,7 +104,8 @@ func AllocateCPUMemory(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
-//ScheduleCPU is a handler for route /cpu and returns a collection of host ids that can be scheduled on
+// DeallocateCPUMemory is a handler for route /cpu and returns a collection of host ids that can
+// be scheduled on
 func DeallocateCPUMemory(w http.ResponseWriter, r *http.Request) {
 	log.Info("DeallocateCPUMemory called")
 

--- a/service/routes.go
+++ b/service/routes.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"net/http"
+	"strconv"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
+	"github.com/rancher/go-rancher/api"
+	"github.com/rancher/go-rancher/client"
+)
+
+//MuxWrapper is a wrapper over the mux router that returns 503 until catalog is ready
+type MuxWrapper struct {
+	IsReady bool
+	Router  *mux.Router
+}
+
+//Route defines the properties of a go mux http route
+type Route struct {
+	Name        string
+	Method      string
+	Pattern     string
+	HandlerFunc http.HandlerFunc
+}
+
+var schemas *client.Schemas
+
+//Routes array of Route defined
+type Routes []Route
+
+func (httpWrapper *MuxWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if httpWrapper.IsReady {
+		//delegate to the mux router
+		httpWrapper.Router.ServeHTTP(w, r)
+	} else {
+		log.Debugf("Service Unavailable")
+		ReturnHTTPError(w, r, http.StatusServiceUnavailable, "Service is not yet available, please try again later")
+	}
+}
+
+//ReturnHTTPError handles sending out SchedulerError response
+func ReturnHTTPError(w http.ResponseWriter, r *http.Request, httpStatus int, errorMessage string) {
+	w.WriteHeader(httpStatus)
+
+	err := SchedulerError{
+		Resource: client.Resource{
+			Type: "error",
+		},
+		Status:  strconv.Itoa(httpStatus),
+		Message: errorMessage,
+	}
+
+	api.CreateApiContext(w, r, schemas)
+	api.GetApiContext(r).Write(&err)
+
+}
+
+//NewRouter creates and configures a mux router
+func NewRouter() *mux.Router {
+	schemas = &client.Schemas{}
+
+	// ApiVersion
+	schemas.AddType("schedule", Response{})
+
+	// API framework routes
+	router := mux.NewRouter().StrictSlash(true)
+
+	router.Methods("GET").Path("/").Handler(api.VersionsHandler(schemas, "v1-scheduler"))
+	router.Methods("GET").Path("/v1-scheduler/schemas").Handler(api.SchemasHandler(schemas))
+	router.Methods("GET").Path("/v1-scheduler/schemas/{id}").Handler(api.SchemaHandler(schemas))
+	router.Methods("GET").Path("/v1-scheduler").Handler(api.VersionHandler(schemas, "v1-scheduler"))
+
+	// Application routes
+	for _, route := range routes {
+		router.
+			Methods(route.Method).
+			Path(route.Pattern).
+			Name(route.Name).
+			Handler(api.ApiHandler(schemas, route.HandlerFunc))
+	}
+
+	return router
+}
+
+var routes = Routes{
+	Route{
+		"ScheduleCPUMemory",
+		"POST",
+		"/v1-scheduler/cpu-memory",
+		ScheduleCPUMemory,
+	},
+	Route{
+		"AllocateCPUMemory",
+		"POST",
+		"/v1-scheduler/allocate-cpu-memory",
+		AllocateCPUMemory,
+	},
+	Route{
+		"DeallocateCPUMemory",
+		"POST",
+		"/v1-scheduler/deallocate-cpu-memory",
+		DeallocateCPUMemory,
+	},
+	Route{
+		"ScheduleIops",
+		"POST",
+		"/v1-scheduler/iops",
+		ScheduleIops,
+	},
+	Route{
+		"AllocateIops",
+		"POST",
+		"/v1-scheduler/allocate-iops",
+		AllocateIops,
+	},
+	Route{
+		"DeallocateIops",
+		"POST",
+		"/v1-scheduler/deallocate-iops",
+		DeallocateIops,
+	},
+	Route{
+		"RemoveInstance",
+		"POST",
+		"/v1-scheduler/remove-instance",
+		RemoveInstance,
+	},
+	Route{
+		"RemoveHost",
+		"POST",
+		"/v1-scheduler/remove-host",
+		RemoveHost,
+	},
+}

--- a/service/routes.go
+++ b/service/routes.go
@@ -35,7 +35,8 @@ func (httpWrapper *MuxWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		httpWrapper.Router.ServeHTTP(w, r)
 	} else {
 		log.Debugf("Service Unavailable")
-		ReturnHTTPError(w, r, http.StatusServiceUnavailable, "Service is not yet available, please try again later")
+		ReturnHTTPError(w, r, http.StatusServiceUnavailable,
+			"Service is not yet available, please try again later")
 	}
 }
 


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/3153
- initial implementation of scheduler in Go micro-service. 
- The current functionality is to schedule cpu/memory/iops. CPU and Memory is for VM, iops for both container and VM instances. 
- The Cattle side scheduling task will use Rest API exposed by this micro-service to question if instance schedule-able or not and also do resource allocation calls if it can be scheduled.
- Scheduler keeps track of how much resource got allocated and how much left for other instances.

Limitation of this version: 
- support only one read_iops label and one write_iops label which maps to default device "/dev/sda".
- for each host, Cattle will make a scheduling request, instead of passing all hosts in for scheduling a instance. This limitation is due to easy implementation at the Cattle side as well as Rest API call.
- vcpu count is always half of core count on the host, assuming all cores are hyper-threaded. This limitation needs to be addressed when py-agent returns not only core count, but also threads count.

@cjellick @ibuildthecloud 
