### PR TITLE
Fix prioritize logic to handle duplicate resources

### DIFF
--- a/events/handler.go
+++ b/events/handler.go
@@ -51,7 +51,7 @@ func (h *schedulingHandler) Prioritize(event *revents.Event, client *client.Ranc
 
 	candidates, err := h.scheduler.PrioritizeCandidates(data.ResourceRequests)
 	if err != nil {
-		return errors.Wrapf(err, "Error prioritizing candidates.")
+		return errors.Wrapf(err, "Error prioritizing candidates. Event %v", event)
 	}
 
 	eventDataWrapper := map[string]interface{}{"prioritizedCandidates": candidates}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -202,7 +202,7 @@ type OverReserveError struct {
 }
 
 func (e OverReserveError) Error() string {
-	return fmt.Sprintf("Not enough available resources on host %v to resserve %v.", e.hostID, e.resourceRequest)
+	return fmt.Sprintf("Not enough available resources on host %v to reserve %v.", e.hostID, e.resourceRequest)
 }
 
 type OverReleaseError struct {

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -48,6 +48,9 @@ func (s *SchedulerTestSuite) TestReserveResource(c *check.C) {
 		// Host 2 has more memory for first iteration
 		{"1", false, []ResourceRequest{{Amount: 1, Resource: "memory"}, {Amount: 1, Resource: "storage.size"}}, []string{"2", "1"}},
 
+		// Double memory requests result in no hosts with enough memory
+		{"2-memory-requests", false, []ResourceRequest{{Amount: 3, Resource: "memory"}, {Amount: 3, Resource: "memory"}}, []string{}},
+
 		// Host 2 still has more memory. Request has two memory resource requests
 		{"2", false, []ResourceRequest{{Amount: 1, Resource: "memory"}, {Amount: 1, Resource: "memory"}, {Amount: 1, Resource: "storage.size"}}, []string{"2", "1"}},
 

--- a/scheduler/sort.go
+++ b/scheduler/sort.go
@@ -2,9 +2,22 @@ package scheduler
 
 func filter(hosts map[string]*host, resourceRequests []ResourceRequest) []*host {
 	filtered := []*host{}
+	aggregateResReqs := map[string]*ResourceRequest{}
+	for _, rr := range resourceRequests {
+		aggResReq, ok := aggregateResReqs[rr.Resource]
+		if !ok {
+			aggResReq = &ResourceRequest{
+				Resource: rr.Resource,
+				Amount:   0,
+			}
+			aggregateResReqs[rr.Resource] = aggResReq
+		}
+		aggResReq.Amount += rr.Amount
+	}
+
 Outer:
 	for _, h := range hosts {
-		for _, rr := range resourceRequests {
+		for _, rr := range aggregateResReqs {
 			pool, ok := h.pools[rr.Resource]
 			if !ok || (pool.total-pool.used) < rr.Amount {
 				continue Outer


### PR DESCRIPTION
In the case of deployment units, requests can come in that have the
same resource type requested more than once. I.e., a request can come
in that asks for 300 compute and 400 compute. This fix allows the
prioritization logic to handle such requests in aggregate.
