### PR TITLE
don't update portpool if it is nil

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -11,8 +11,8 @@ RUN apt-get update && \
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.8.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get -u github.com/rancher/trash && go get -u github.com/golang/lint/golint
+RUN wget -O - https://storage.googleapis.com/golang/go1.9.7.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+    go get -u github.com/rancher/trash && go get -u golang.org/x/lint/golint
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \

--- a/resourcewatchers/metadata.go
+++ b/resourcewatchers/metadata.go
@@ -109,25 +109,26 @@ func (w *metadataWatcher) updateFromMetadata(mdVersion string) {
 		if err != nil {
 			w.checkError(err)
 		}
-		poolDoesntExist := !w.resourceUpdater.UpdateResourcePool(h.UUID, portPool)
-		if poolDoesntExist {
-			w.resourceUpdater.CreateResourcePool(h.UUID, portPool)
-		} else if w.previousIPs[h.UUID] != h.Labels[ipLabel] {
-			portPool.ShouldUpdate = true
-			w.resourceUpdater.UpdateResourcePool(h.UUID, portPool)
+		if portPool != nil {
+			poolDoesntExist := !w.resourceUpdater.UpdateResourcePool(h.UUID, portPool)
+			if poolDoesntExist {
+				w.resourceUpdater.CreateResourcePool(h.UUID, portPool)
+			} else if w.previousIPs[h.UUID] != h.Labels[ipLabel] {
+				portPool.ShouldUpdate = true
+				w.resourceUpdater.UpdateResourcePool(h.UUID, portPool)
+			}
+			w.previousIPs[h.UUID] = h.Labels[ipLabel]
 		}
-		w.previousIPs[h.UUID] = h.Labels[ipLabel]
 
 		// updating label pool
 		labelPool := &scheduler.LabelPool{
 			Resource: hostLabels,
 			Labels:   h.Labels,
 		}
-		poolDoesntExist = !w.resourceUpdater.UpdateResourcePool(h.UUID, labelPool)
+		poolDoesntExist := !w.resourceUpdater.UpdateResourcePool(h.UUID, labelPool)
 		if poolDoesntExist {
 			w.resourceUpdater.CreateResourcePool(h.UUID, labelPool)
 		}
-
 	}
 
 	for uuid := range w.knownHosts {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/10252.When system is
overloaded the metadata call to get all containers may timeout and
return nil portpool.(portpool is calcaluted from all ports of all
containers running in the current environment). In this case we skip
updating portpool and continue, but increase the failure count so that
scheduler can exit when count reaches threhold(5).